### PR TITLE
isolate jwt token

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -77,7 +77,7 @@ class LoginController extends Controller
             $this->clearLoginAttempts($request);
             $token = JWTAuth::fromUser($user);
 
-            return redirect('api/app/callback?token=' . $token);
+            return redirect('api/app/callback?token=' . $token . '&success=true');
         }
 
         return $this->sendFailedLoginResponse($request);


### PR DESCRIPTION
The jwt token url is sometimes polluted with some extra symbols at the very end and thus a solution to that problem was to append a known string at the very end so that the string can be extracted properly.